### PR TITLE
ARCH: Location self-referencing setup

### DIFF
--- a/app/models/location.rb
+++ b/app/models/location.rb
@@ -1,0 +1,8 @@
+class Location < ApplicationRecord
+  has_many :politicians
+  has_many :child_locations, class_name: "Location", foreign_key: "parent_location_id"
+  belongs_to :parent_location, class_name: "Location", optional: true
+
+  enum location_type: [:country, :state, :city]
+
+end

--- a/app/models/politician.rb
+++ b/app/models/politician.rb
@@ -1,2 +1,4 @@
 class Politician < ApplicationRecord
+  belongs_to :location, class_name: "Location", foreign_key: "location_id"
+
 end

--- a/db/migrate/20210202204457_create_locations.rb
+++ b/db/migrate/20210202204457_create_locations.rb
@@ -1,0 +1,11 @@
+class CreateLocations < ActiveRecord::Migration[6.0]
+  def change
+    create_table :locations do |t|
+      t.string :name
+      t.integer :location_type
+      t.references :parent_location, foreign_key: { to_table: :locations }
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,10 +10,19 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_12_23_200844) do
+ActiveRecord::Schema.define(version: 2021_02_02_204457) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
+
+  create_table "locations", force: :cascade do |t|
+    t.string "name"
+    t.integer "location_type"
+    t.bigint "parent_location_id"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["parent_location_id"], name: "index_locations_on_parent_location_id"
+  end
 
   create_table "politicians", force: :cascade do |t|
     t.string "first_name"
@@ -34,4 +43,5 @@ ActiveRecord::Schema.define(version: 2020_12_23_200844) do
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end
 
+  add_foreign_key "locations", "locations", column: "parent_location_id"
 end

--- a/test/fixtures/locations.yml
+++ b/test/fixtures/locations.yml
@@ -1,0 +1,9 @@
+# Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+one:
+  name: MyString
+  type: 1
+
+two:
+  name: MyString
+  type: 1

--- a/test/models/location_test.rb
+++ b/test/models/location_test.rb
@@ -1,0 +1,7 @@
+require 'test_helper'
+
+class LocationTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
# Pull Request
## Description :speak_no_evil:
ARCH: Location model+migration added

RTFM: https://guides.rubyonrails.org/association_basics.html

![image](https://user-images.githubusercontent.com/70934030/106680106-16080180-6612-11eb-994b-e7c1da7f31cc.png)




## Commands to run
`raild db:migrate`

		
## Changes :octopus:
**Routes** 
-n/a

**Model**
- Location model added as well as migration file

**Controllers**
-n/a

**View**
- n/a
		
## How Has This Been Tested? :microscope:
- [x] rails c
![image](https://user-images.githubusercontent.com/70934030/106679916-af82e380-6611-11eb-8268-ebc2e341cb56.png)
